### PR TITLE
fix: change headers to sentence case

### DIFF
--- a/_template.qmd
+++ b/_template.qmd
@@ -10,21 +10,21 @@ categories:
 Use other decision posts as inspiration to writing these.
 :::
 
-## Context and Problem Statement
+## Context and problem statement
 
 ::: content-hidden
 State the context and some background on the issue, then write a
 statement in the form of a question for the problem.
 :::
 
-## Decision Drivers
+## Decision drivers
 
 ::: content-hidden
 List some reasons for why we need to make this decision and what things
 have arisen that impact work.
 :::
 
-## Considered Options
+## Considered options
 
 ::: content-hidden
 List and describe some of the options, as well as some of the benefits and
@@ -46,7 +46,7 @@ drawbacks for each option.
 :::
 :::
 
-## Decision Outcome
+## Decision outcome
 
 ::: content-hidden
 What decision was made, use the form "We decided on CHOICE because of


### PR DESCRIPTION


## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR changes the headers to sentence case in the template
- Quoting @lwjohnst86 : General style guidelines (for documents) tend to suggest sentence case for headers, unless following very specific style guides like MLA/Chicago. E.g. https://developers.google.com/style/capitalization and https://learn.microsoft.com/en-us/powershell/scripting/community/contributing/general-markdown?view=powershell-7.4 and https://www.grammarly.com/blog/title-case-sentence-case/ and https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style

## Reviewer Focus
<!-- Please delete as appropriate: -->
This PR only needs a quick review.
