### PR TITLE
chore: :chart_with_upwards_trend: add website visit counter (non-personal data)

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -19,10 +19,10 @@ website:
         href: "https://github.com/seedcase-project/decisions"
         aria-label: "GitHub icon: Source code"
 
-# format:
-#   seedcase-theme-html:
-    # include-before-body:
-      # - "includes/site-counter.html"
+format:
+  seedcase-theme-html:
+    include-before-body:
+      - "site-counter.html"
 
 editor:
   markdown:

--- a/site-counter.html
+++ b/site-counter.html
@@ -1,0 +1,1 @@
+<script data-goatcounter="https://seedcase-project-decisions.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>


### PR DESCRIPTION

## Description

This adds a non-personal data, simple website visit counter. Because it doesn't trigger GDPR, we don't need a consent form since no identifiable data is collected.

See seedcase-project/.github#137

This PR needs a quick review.

## Checklist

- [x] Rendered website locally
