### PR TITLE
fix: :pencil2: there was a double quote accidentally

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -5,7 +5,7 @@ about:
   template: jolla
   image: home.svg
   image-title: "Making decisions"
-  image-alt: "A cartoon illustration of a person with their arms outstretched looking uncertain, with a green arrow and black arrow pointing in opposite directions, symbolising a choice or decision.""
+  image-alt: "A cartoon illustration of a person with their arms outstretched looking uncertain, with a green arrow and black arrow pointing in opposite directions, symbolising a choice or decision."
   image-shape: rectangle
   image-width: 20rem
 listing:


### PR DESCRIPTION
## Description

After the PR review, a suggestion edit had an accidental double quote, which gave an error. This fixes it.

No need for a review.

## Checklist

- [x] Rendered website locally
