### PR TITLE
docs: :memo: add pages for current and previous decisions

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -11,6 +11,9 @@ website:
     logo-alt: "Seedcase Decisions logo: Main page"
     pinned: true
     search: true
+    left:
+      - current.qmd
+      - previous.qmd
     tools:
       - icon: house
         href: "https://seedcase-project.org"

--- a/current.qmd
+++ b/current.qmd
@@ -1,0 +1,19 @@
+---
+title: Current
+listing:
+  contents: why-*/*.qmd
+  categories: true
+  type: grid
+  exclude:
+    previous: true
+  fields:
+    - title
+    - description
+    - date
+  sort: "date desc"
+  max-items: 50
+---
+
+These decision posts are ones we currently use and follow. All our
+decisions adhere to our [values and
+principles](https://design.seedcase-project.org/).

--- a/current.qmd
+++ b/current.qmd
@@ -14,6 +14,6 @@ listing:
   max-items: 50
 ---
 
-These decision posts are ones we currently use and follow. All our
+These decision posts reflect the decisions we currently adhere to. All our
 decisions adhere to our [values and
 principles](https://design.seedcase-project.org/).

--- a/index.qmd
+++ b/index.qmd
@@ -1,23 +1,13 @@
 ---
 title: Archive of Decision Records
+toc: false
 about:
-  id: hero-heading
   template: jolla
   image: home.svg
   image-title: "Making decisions"
   image-alt: "A cartoon illustration of a person with their arms outstretched looking uncertain, with a green arrow and black arrow pointing in opposite directions, symbolising a choice or decision."
   image-shape: rectangle
   image-width: 20rem
-listing:
-  id: decisions
-  contents: why-*/*.qmd
-  categories: true
-  type: grid
-  fields:
-    - title
-    - description
-    - date
-  sort: "title"
 ---
 
 ```{=html}
@@ -28,23 +18,10 @@ div.quarto-about-jolla {
 </style>
 ```
 
-::: column-screen
-::: {#hero-heading}
 Decision records inspired by [Architectural Decision
-Records](https://adr.github.io/). 
+Records](https://adr.github.io/) and written in the
+[Diátaxis](https://diataxis.fr/) explanation format. They describe and
+explain our reasons for why we choose certain tools, technologies, or
+processes for our products and how we work.
 
-*Illustration by [Storyset](https://storyset.com/choice)*
-:::
-:::
-
-<hr>
-
-We write structured decision records (or "posts") describing the reasons
-for why we choose certain tools, technologies, or processes for our
-software, our collaboration workflow, and our websites. All our
-decisions adhere to our [Values and
-principles](https://seedcase-project.org/about/principles).
-
-::: {#decisions}
-:::
-
+## Illustration by [Storyset](https://storyset.com/choice) {.appendix}

--- a/previous.qmd
+++ b/previous.qmd
@@ -14,5 +14,5 @@ listing:
   max-items: 50
 ---
 
-These are decision posts we have previously made and followed but that
-no longer apply or are relevant
+These decision posts reflect previous decisions that are
+no longer applicable or relevant.

--- a/previous.qmd
+++ b/previous.qmd
@@ -1,0 +1,18 @@
+---
+title: Previous
+listing:
+  contents: why-*/*.qmd
+  categories: true
+  type: grid
+  include:
+    previous: true
+  fields:
+    - title
+    - description
+    - date
+  sort: "date desc"
+  max-items: 50
+---
+
+These are decision posts we have previously made and followed but that
+no longer apply or are relevant

--- a/why-containers/index.qmd
+++ b/why-containers/index.qmd
@@ -4,7 +4,7 @@ description: |
   Containers are a way to bundle a software's environment to simplify
   development, installation, and dependency management.
 date: "2022-12-10"
-draft: true
+previous: true
 categories:
   - container
   - installation

--- a/why-django/index.qmd
+++ b/why-django/index.qmd
@@ -4,6 +4,7 @@ description: |
   Web frameworks are designed to support building both web front ends and API layers. Django is a popular full-stack framework with solutions for most web development tasks out of the box.
 date: "2023-03-22"
 date-modified: "2024-05-16"
+previous: true
 categories:
   - development
   - framework

--- a/why-docker/index.qmd
+++ b/why-docker/index.qmd
@@ -4,7 +4,7 @@ description: |
   While there are several container technologies, Docker is one of the
   most popular and commonly used technologies.
 date: "2022-12-14"
-draft: true
+previous: true
 categories:
   - container
   - deploying

--- a/why-fly/index.qmd
+++ b/why-fly/index.qmd
@@ -4,7 +4,7 @@ description: |
   Showcasing a demo of Seedcase software helps make things more tangible. This
   post describes our reasons for using Fly.io as a deployment host for showcasing our demo.
 date: "2023-12-08"
-date-modified: last-modified
+previous: true
 categories:
   - development
   - deploying

--- a/why-material-design/index.qmd
+++ b/why-material-design/index.qmd
@@ -2,6 +2,7 @@
 title: "Why Material Design"
 description: "We aim to utilise existing CSS or UI frameworks instead of building from scratch so Seedcase software products will look good with minimal effort. Since Material Design lives up to these requirements, we have chosen this framework for our software."
 date: "2023-12-15"
+previous: true
 categories:
   - front end
   - style

--- a/why-postgres/index.qmd
+++ b/why-postgres/index.qmd
@@ -5,6 +5,7 @@ description: |
   of SQL. This decision post contains the reasons for using PostgreSQL, which is
   a powerful and feature-full variant of SQL.
 date: "2024-01-05"
+previous: true
 categories:
   - backend
   - database


### PR DESCRIPTION
## Description

Make a page for our old decisions, and move out the current ones into their own page.

Closes #137, closes #156, closes #90 (already done, but order by latest now), closes #155 (but doesn't seem to work when I build it, not sure why).

<!-- Please delete as appropriate: -->
This PR needs a quick review.

## Checklist

- [x] Ran spell-check
- [x] Formatted Markdown
- [x] Ran `just run-all`
