### PR TITLE
feat: :sparkles: post on using Cyclopts for CLIs in Python

### DIFF
--- a/why-cyclopts/index.qmd
+++ b/why-cyclopts/index.qmd
@@ -54,11 +54,10 @@ List and describe some of the options, as well as some of the benefits
 and drawbacks for each option.
 :::
 
-Based on the
-[Awesome Python: Command-Line Interface
+Based on the [Awesome Python: Command-Line Interface
 Development](https://github.com/vinta/awesome-python#command-line-interface-development)
-list, we considered these packages, since they were still actively maintained
-and developed at the time of this post:
+list, we considered these packages, since they were still actively
+maintained and developed at the time of this post:
 
 -   [Argparse](https://docs.python.org/3/library/argparse.html)
 -   [Python Fire](https://python-fire.readthedocs.io/en/latest/)
@@ -98,10 +97,12 @@ Argparse is a part of the standard library in Python for building CLIs.
     documentation) is not easy to follow or read.
 -   Needs to duplicate a lot of code and information between the
     function/class signatures and the argument parsing code.
--   Lacks a lot of features (hence requires the duplicate code mentioned above) that they openly state in the documentation,
-    and even refers to [click and
+-   Lacks a lot of features (hence requires the duplicate code mentioned
+    above) that they openly state in the documentation, and even refers
+    to [click and
     Typer](https://docs.python.org/3/library/optparse.html#choosing-an-argument-parsing-library)
-    as alternatives, stating that e.g., Typer integrates with type hints.
+    as alternatives, stating that e.g., Typer integrates with type
+    hints.
 :::
 :::::
 
@@ -112,8 +113,8 @@ Fire](https://python-fire.readthedocs.io/en/latest/), including their
 own documentation, so we can't really describe it that well. Based on
 their tag line, it is:
 
-> [...] a library for automatically generating command line
-> interfaces (CLIs) from absolutely any Python object.
+> \[...\] a library for automatically generating command line interfaces
+> (CLIs) from absolutely any Python object.
 
 ::::: columns
 ::: column
@@ -202,8 +203,8 @@ limitations](https://cyclopts.readthedocs.io/en/latest/vs_typer/README.html).
     the ground up to take advantage of modern Python features like type
     hints and docstring parsing.
 -   Very ergonomic and requires little to no boilerplate code.
--   Includes features like parsing docstrings for help texts,
-    including the argument/option help text.
+-   Includes features like parsing docstrings for help texts, including
+    the argument/option help text.
 -   Can check input values against a set of allowed values, for both
     string and number types.
 -   Supports `Union` types, which also means it can support `Optional`

--- a/why-cyclopts/index.qmd
+++ b/why-cyclopts/index.qmd
@@ -1,0 +1,266 @@
+---
+title: "Why Cyclopts for Python CLIs"
+description: "Python isn't natively designed to build command line interfaces (CLIs), so we need to choose a package to help us build them. In this post, we describe why we chose Cyclopts."
+date: "2026-01-26"
+categories:
+- python
+- tool
+- develop
+---
+
+::: content-hidden
+Use other decision posts as inspiration to writing these. Leave the
+content-hidden sections in the text for future reference.
+:::
+
+## Context and problem statement
+
+::: content-hidden
+State the context and some background on the issue, then write a
+statement in the form of a question for the problem.
+:::
+
+We want to build command line interfaces (CLIs) for some of our Python
+tools. Python doesn't natively support building CLIs, nor was it
+designed initially to do that. However, there are many packages
+available, including some built-in standard libraries, for exposing a
+Python package as a CLI application. So the question is:
+
+**Which package should we use to build command line interfaces (CLIs)
+for our Python tools?**
+
+## Decision drivers
+
+::: content-hidden
+List some reasons for why we need to make this decision and what things
+have arisen that impact work.
+:::
+
+Aside from our [design
+principles](https://design.seedcase-project.org/software/principles)
+that we generally follow when using or choosing software, the package
+needs to be:
+
+-   Well maintained and actively developed.
+-   Integrates easily into our current development workflow and style.
+-   Ergonomic and easy to use, so we can develop CLIs quickly and
+    easily.
+-   Has excellent documentation that is easy to follow.
+
+## Considered options
+
+::: content-hidden
+List and describe some of the options, as well as some of the benefits
+and drawbacks for each option.
+:::
+
+These are the packages we considered that were still actively maintained
+and developed at the time of this post, which was taken from the
+[Awesome Python: Command-Line Interface
+Development](https://github.com/vinta/awesome-python#command-line-interface-development)
+list.
+
+-   [Argparse](https://docs.python.org/3/library/argparse.html)
+-   [Python Fire](https://python-fire.readthedocs.io/en/latest/)
+-   [Click](https://click.palletsprojects.com/en/stable/)
+-   [Typer](https://typer.tiangolo.com/)
+-   [Cyclopts](https://cyclopts.readthedocs.io/en/latest/index.html)
+
+There are a few others that almost matched our criteria, but didn't in
+one way or another:
+
+-   [cement](https://docs.builtoncement.com/en/latest/): It isn't that
+    actively maintained, but importantly, it seems to be more of an
+    advanced framework for building CLIs (e.g. with Dockerfiles), which
+    is more than what we need.
+-   [prompt_toolkit](https://python-prompt-toolkit.readthedocs.io/en/latest/):
+    Designed more for building "full screen" terminal applications,
+    which is more than what we need.
+-   [cliff](https://docs.openstack.org/cliff/latest/): Is not regularly
+    updated. The documentation was last updated in 2021.
+
+### Argparse
+
+This is part of the standard library in Python for building CLIs.
+
+::::: columns
+::: column
+#### Benefits
+
+-   Comes built-in with Python, so no extra dependencies.
+:::
+
+::: column
+#### Drawbacks
+
+-   Not very ergonomic and requires a lot of code to set up.
+-   The documentation (like a lot of Python standard library
+    documentation) is not easy to follow or read.
+-   Needs to duplicate a lot of code and information between the
+    function/class signatures and the argument parsing code.
+-   Lacks a lot of features that they openly state in the documentation,
+    and even state that [click or
+    Typer](https://docs.python.org/3/library/optparse.html#choosing-an-argument-parsing-library)
+    would be better alternatives, especially Typer as it uses the type
+    hints when building the CLI, which can simplify a lot of the code.
+:::
+:::::
+
+### Python Fire
+
+There isn't as much information (blogs, tutorials, etc) about [Python
+Fire](https://python-fire.readthedocs.io/en/latest/), including their
+own documentation, so it's can't really describe it that well. Based on
+their tag line, it is:
+
+> Python Fire is a library for automatically generating command line
+> interfaces (CLIs) from absolutely any Python object.
+
+::::: columns
+::: column
+#### Benefits
+
+-   A Google built library (though not an official product).
+-   A lot of GitHub stars, so seems to be popular.
+:::
+
+::: column
+#### Drawbacks
+
+-   The documentation is sparse, disorganised, and not very beginner
+    friendly.
+-   Given the documentation, it's very difficult to assess it well
+    enough to make an informed decision.
+:::
+:::::
+
+### Click
+
+A widely used, very popular library for building CLIs in Python.
+
+::::: columns
+::: column
+#### Benefits
+
+-   Because of its popularity, there are a lot of resources available
+    online to learn from.
+-   Has a lot of features and is very flexible and powerful.
+:::
+
+::: column
+#### Drawbacks
+
+-   Requires a lot of decorators, one for each CLI argument/option, for
+    each function that would be a CLI command.
+-   Because it was developed before Python had type hints, it doesn't
+    use them, so there is a lot of duplicated information between the
+    function signatures and the decorators.
+-   It is an older package, so was designed before some of the more
+    modern Python features were available (e.g. type hints, docstring
+    parsing).
+:::
+:::::
+
+### Typer
+
+A newer library for building CLIs in Python that is built on top of
+Click, but designed to take advantage of modern Python features like
+type hints.
+
+::::: columns
+::: column
+#### Benefits
+
+-   Documentation is very well written, easy to follow, and beginner
+    friendly.
+-   Like Click, it is very widely used and popular, so there are a lot
+    of resources available.
+-   Of the previous options, this is the newest and most well-designed.
+-   While only "owned" by one person, it has a core team of maintainers.
+:::
+
+::: column
+#### Drawbacks
+
+-   Because it was built on top of Click, it inherits some of its
+    drawbacks.
+-   Still needs some level of boilerplate and duplication of code (e.g.
+    CLI help text needs to be written in both the function docstring and
+    the argument/option declaration via `Annotated` Python code).
+:::
+:::::
+
+### Cyclopts
+
+A package specifically designed to resolve some of [Typer's
+limitations](https://cyclopts.readthedocs.io/en/latest/vs_typer/README.html).
+
+::::: columns
+::: column
+#### Benefits
+
+-   Rather than build on top of previous packages, it is designed from
+    the ground up to take advantage of modern Python features like type
+    hints and docstring parsing.
+-   Very ergonomic and requires little to no boilerplate code.
+-   Includes features like parsing docstrings for the help text,
+    including for the argument/option help text.
+-   Can check input values against a set of allowed values, for both
+    string and number types.
+-   Supports `Union` types, which also means it can support `Optional`
+    types natively.
+-   Multiple input values to an argument/option are supported.
+:::
+
+::: column
+#### Drawbacks
+
+-   It is a newer package with a smaller user base, so there are fewer
+    resources available online.
+-   Because it is newer, it might have more undiscovered bugs or missing
+    features.
+-   Since it is still in active development, there might be breaking
+    changes in future releases.
+-   Seems to be developed by only one person, so long-term maintenance
+    is uncertain.
+:::
+:::::
+
+## Decision outcome
+
+::: content-hidden
+What decision was made, use the form "We decided on CHOICE because of
+REASONS."
+:::
+
+We decided on Cyclopts because of its modern design, ergonomics, and
+features that interact nicely with how we develop. In particular, it
+addresses some of Typer's limitations (which would have been our second
+choice) as these design decisions would make our code leaner and easier
+to develop and maintain.
+
+### Consequences
+
+::: content-hidden
+List some potential consequences of this decision.
+:::
+
+-   Because it is a much newer package, there might be some issues that
+    come up that lead to breaking changes that we'd have to resolve.
+-   Long term maintenance is uncertain, so if the package is abandoned,
+    we might have to switch to another package in the future.
+
+## Resources used for this post
+
+::: content-hidden
+List the resources used to write this post
+:::
+
+-   [Python Packaging User Guide: Creating and packaging command-line
+    tools](https://packaging.python.org/en/latest/guides/creating-command-line-tools/)
+-   [Typer: Alternatives, Inspirations, and
+    Comparisons](https://typer.tiangolo.com/alternatives/)
+-   [Typer: Probably the Simplest to Use Python Command Line Interface
+    Library](https://towardsdatascience.com/typer-probably-the-simplest-to-use-python-command-line-interface-library-17abf1a5fd3e/)
+-   [Awesome Python: Command-Line Interface
+    Development](https://github.com/vinta/awesome-python#command-line-interface-development)

--- a/why-cyclopts/index.qmd
+++ b/why-cyclopts/index.qmd
@@ -98,7 +98,7 @@ Argparse is a part of the standard library in Python for building CLIs.
     documentation) is not easy to follow or read.
 -   Needs to duplicate a lot of code and information between the
     function/class signatures and the argument parsing code.
--   Lacks a lot of features that they openly state in the documentation,
+-   Lacks a lot of features (hence requires the duplicate code mentioned above) that they openly state in the documentation,
     and even refers to [click and
     Typer](https://docs.python.org/3/library/optparse.html#choosing-an-argument-parsing-library)
     as alternatives, stating that e.g., Typer integrates with type hints.

--- a/why-cyclopts/index.qmd
+++ b/why-cyclopts/index.qmd
@@ -73,9 +73,9 @@ one way or another:
     advanced framework for building CLIs (e.g. with Dockerfiles), which
     is more complex than what we need.
 -   [prompt_toolkit](https://python-prompt-toolkit.readthedocs.io/en/latest/):
-    Is designed more for building "full screen" terminal applications,
+    It is designed more for building "full screen" terminal applications,
     which is more complex than what we need.
--   [cliff](https://docs.openstack.org/cliff/latest/): Is not regularly
+-   [cliff](https://docs.openstack.org/cliff/latest/): It isn't regularly
     updated. The documentation was last updated in 2021.
 
 ### Argparse

--- a/why-cyclopts/index.qmd
+++ b/why-cyclopts/index.qmd
@@ -21,7 +21,7 @@ statement in the form of a question for the problem.
 :::
 
 We want to build command line interfaces (CLIs) for some of our Python
-tools. Python doesn't natively support building CLIs, nor was it
+tools, but Python doesn't natively support building CLIs, nor was it
 designed initially to do that. However, there are many packages
 available, including some built-in standard libraries, for exposing a
 Python package as a CLI application. So the question is:
@@ -39,13 +39,13 @@ have arisen that impact work.
 Aside from our [design
 principles](https://design.seedcase-project.org/software/principles)
 that we generally follow when using or choosing software, the package
-needs to be:
+needs to:
 
--   Well maintained and actively developed.
--   Integrates easily into our current development workflow and style.
--   Ergonomic and easy to use, so we can develop CLIs quickly and
+-   Be well maintained and actively developed.
+-   Integrate easily into our current development workflow and style.
+-   Be ergonomic and easy to use, so we can develop CLIs quickly and
     easily.
--   Has excellent documentation that is easy to follow.
+-   Have excellent documentation that is easy to follow.
 
 ## Considered options
 
@@ -54,11 +54,11 @@ List and describe some of the options, as well as some of the benefits
 and drawbacks for each option.
 :::
 
-These are the packages we considered that were still actively maintained
-and developed at the time of this post, which was taken from the
+Based on the
 [Awesome Python: Command-Line Interface
 Development](https://github.com/vinta/awesome-python#command-line-interface-development)
-list.
+list, we considered these packages, since they were still actively maintained
+and developed at the time of this post:
 
 -   [Argparse](https://docs.python.org/3/library/argparse.html)
 -   [Python Fire](https://python-fire.readthedocs.io/en/latest/)
@@ -72,16 +72,16 @@ one way or another:
 -   [cement](https://docs.builtoncement.com/en/latest/): It isn't that
     actively maintained, but importantly, it seems to be more of an
     advanced framework for building CLIs (e.g. with Dockerfiles), which
-    is more than what we need.
+    is more complex than what we need.
 -   [prompt_toolkit](https://python-prompt-toolkit.readthedocs.io/en/latest/):
-    Designed more for building "full screen" terminal applications,
-    which is more than what we need.
+    Is designed more for building "full screen" terminal applications,
+    which is more complex than what we need.
 -   [cliff](https://docs.openstack.org/cliff/latest/): Is not regularly
     updated. The documentation was last updated in 2021.
 
 ### Argparse
 
-This is part of the standard library in Python for building CLIs.
+Argparse is a part of the standard library in Python for building CLIs.
 
 ::::: columns
 ::: column
@@ -99,10 +99,9 @@ This is part of the standard library in Python for building CLIs.
 -   Needs to duplicate a lot of code and information between the
     function/class signatures and the argument parsing code.
 -   Lacks a lot of features that they openly state in the documentation,
-    and even state that [click or
+    and even refers to [click and
     Typer](https://docs.python.org/3/library/optparse.html#choosing-an-argument-parsing-library)
-    would be better alternatives, especially Typer as it uses the type
-    hints when building the CLI, which can simplify a lot of the code.
+    as alternatives, stating that e.g., Typer integrates with type hints.
 :::
 :::::
 
@@ -110,10 +109,10 @@ This is part of the standard library in Python for building CLIs.
 
 There isn't as much information (blogs, tutorials, etc) about [Python
 Fire](https://python-fire.readthedocs.io/en/latest/), including their
-own documentation, so it's can't really describe it that well. Based on
+own documentation, so we can't really describe it that well. Based on
 their tag line, it is:
 
-> Python Fire is a library for automatically generating command line
+> [...] a library for automatically generating command line
 > interfaces (CLIs) from absolutely any Python object.
 
 ::::: columns
@@ -121,7 +120,7 @@ their tag line, it is:
 #### Benefits
 
 -   A Google built library (though not an official product).
--   A lot of GitHub stars, so seems to be popular.
+-   A lot of GitHub stars, so it seems to be popular.
 :::
 
 ::: column
@@ -155,8 +154,8 @@ A widely used, very popular library for building CLIs in Python.
 -   Because it was developed before Python had type hints, it doesn't
     use them, so there is a lot of duplicated information between the
     function signatures and the decorators.
--   It is an older package, so was designed before some of the more
-    modern Python features were available (e.g. type hints, docstring
+-   It is an older package, so it was designed before some of the more
+    modern Python features were available (e.g. type hints and docstring
     parsing).
 :::
 :::::
@@ -174,7 +173,7 @@ type hints.
 -   Documentation is very well written, easy to follow, and beginner
     friendly.
 -   Like Click, it is very widely used and popular, so there are a lot
-    of resources available.
+    of resources available to learn from.
 -   Of the previous options, this is the newest and most well-designed.
 -   While only "owned" by one person, it has a core team of maintainers.
 :::
@@ -203,8 +202,8 @@ limitations](https://cyclopts.readthedocs.io/en/latest/vs_typer/README.html).
     the ground up to take advantage of modern Python features like type
     hints and docstring parsing.
 -   Very ergonomic and requires little to no boilerplate code.
--   Includes features like parsing docstrings for the help text,
-    including for the argument/option help text.
+-   Includes features like parsing docstrings for help texts,
+    including the argument/option help text.
 -   Can check input values against a set of allowed values, for both
     string and number types.
 -   Supports `Union` types, which also means it can support `Optional`


### PR DESCRIPTION
# Description

Found out that Typer isn't the best for our case, but instead Cyclopts (a newer package) is.

Closes #234

Needs a thorough review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
