### PR TITLE
ci: 🐛 switch to single quotes, workflows can't use double

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -46,7 +46,7 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
 
       - name: Assign PR to creator
-        if: ${{ github.event_name == "pull_request" }}
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           gh pr edit $PR --add-assignee $AUTHOR --repo $REPO
         env:


### PR DESCRIPTION
# Description

Very unexpected, can't use double quotes.

Needs no review.

## Checklist

- [x] Ran `just run-all`
