### PR TITLE
chore: 🧑‍💻 remove scopes and use panache in VS Code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -11,7 +11,8 @@
     "pshaddel.conventional-branch",
     "EditorConfig.EditorConfig",
     "tekumara.typos-vscode",
-    "rvben.rumdl"
+    "rvben.rumdl",
+    "jolars.panache"
   ],
   "unwantedRecommendations": []
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,5 @@
 {
-  "files.autoSave": "onFocusChange",
-  "editor.wordWrap": "off",
   "editor.formatOnSave": true,
-  "git.autofetch": false,
-  "editor.tabCompletion": "on",
   "editor.snippetSuggestions": "inline",
   "conventional-branch.type": [
     "build",
@@ -19,5 +15,10 @@
     "perf"
   ],
   "conventional-branch.format": "{Type}/{Branch}",
+  "[quarto][qmd][md]": {
+    "editor.defaultFormatter": "jolars.panache"
+  },
   "files.insertFinalNewline": true,
+  "conventionalCommits.emojiFormat": "emoji",
+  "conventionalCommits.promptScopes": false
 }


### PR DESCRIPTION
# Description

Removes the Conventional Commits scope and adds Panache to VSCode settings.

Needs no review.

## Checklist

- [x] Ran `just run-all`
