### PR TITLE
ci: 🔥 remove Conventional Commit scope from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,3 @@ updates:
       interval: monthly
     commit-message:
       prefix: ci
-      include: scope


### PR DESCRIPTION
# Description

Since we've agreed not to be using this anymore.

Needs no review.

## Checklist

- [x] Ran `just run-all`
