### PR TITLE
chore: 🧑‍💻 use new team for CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
-# All members on the team get added to review PRs
-* @seedcase-project/developers
+# Which team or person to inform for PRs that modify these files.
+# `*` means all files in the repository.
+* @seedcase-project/platform-docs


### PR DESCRIPTION
# Description

Since we've split GitHub teams up into more precise ownership structures.

Needs no review.

## Checklist

- [x] Ran `just run-all`
