### PR TITLE
chore: 🙈 ignore cache folder in `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@ _book
 public
 site
 
-**/*.quarto_ipynb
+# Cache folders
+*_cache/


### PR DESCRIPTION
# Description

Since the Markdown formatters create cache folders.

Needs no review.

## Checklist

- [x] Ran `just run-all`
