### PR TITLE
refactor: ♻️ convert 'Why Pandera' to previous decision

### DIFF
--- a/why-pandera/index.qmd
+++ b/why-pandera/index.qmd
@@ -12,11 +12,11 @@ categories:
 
 ::: callout-important
 We initially decided on Pandera to check the data against the metadata, but
-after using it and identifying more of our needs, we simplified our workflow by 
-saving data as Parquet files which encodes the data types together with the data.
-The data types in the Parquet files are then referenced when creating the metadata.
-schema. So data verification against the metadata is no longer needed as it is
-done during the data cleaning phase.
+after using it and identifying more of our needs, we simplified our workflow by
+saving data as Parquet files which encodes the data types together with the
+data. The data types in the Parquet files are then referenced when creating the
+metadata. schema. So data verification against the metadata is no longer needed
+as it is done during the data cleaning phase.
 :::
 
 ## Context and problem statement

--- a/why-pandera/index.qmd
+++ b/why-pandera/index.qmd
@@ -4,14 +4,19 @@ description: |
   A key functionality of Sprout is checking whether user-supplied data match the metadata that describe them.
   This post explains why we chose to use `pandera` for automating this process.
 date: "2024-11-08"
+previous: true
 categories:
   - develop
   - check
 ---
 
-::: content-hidden
-Use other decision posts as inspiration to writing these. Leave the
-content-hidden sections in the text for future reference.
+::: callout-important
+We initially decided on Pandera to check the data against the metadata, but
+after using it and identifying more of our needs, we switched to simplify
+enforcing data types via saving as Parquet files (which has the data types
+encoded). This data in the Parquet files is then used to create the metadata
+schema. So data verification against the metadata is no longer needed as it is
+done during the data cleaning phase.
 :::
 
 ## Context and problem statement

--- a/why-pandera/index.qmd
+++ b/why-pandera/index.qmd
@@ -12,9 +12,9 @@ categories:
 
 ::: callout-important
 We initially decided on Pandera to check the data against the metadata, but
-after using it and identifying more of our needs, we switched to simplify
-enforcing data types via saving as Parquet files (which has the data types
-encoded). This data in the Parquet files is then used to create the metadata
+after using it and identifying more of our needs, we simplified our workflow by 
+saving data as Parquet files which encodes the data types together with the data.
+The data types in the Parquet files are then referenced when creating the metadata.
 schema. So data verification against the metadata is no longer needed as it is
 done during the data cleaning phase.
 :::


### PR DESCRIPTION
# Description

We use Polars and than save into Parquet to set the data types, which are then used to generate the metadata. So Pandera is no longer used.

Closes #251 

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
