### PR TITLE
ci: 💚 add if contributor guard in new contributors section in `cliff.toml`

### DIFF
--- a/.config/cliff.toml
+++ b/.config/cliff.toml
@@ -82,6 +82,7 @@ body = """
   ### ❤️ New contributors
 {% endif %}
 {% for contributor in github.contributors | filter(attribute="is_first_time", value=true) %}
+  {% if contributor.username %}
   {% if contributor.username is containing("[bot]") %}
   - `@{{ contributor.username }}` started making automated contributions\
   {% else %}
@@ -89,6 +90,7 @@ body = """
     {% if contributor.pr_number %} in \
       [#{{ contributor.pr_number }}]({{ self::remote_url() }}/pull/{{ contributor.pr_number }})\
     {% endif %}
+  {% endif %}
   {% endif %}\
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
# Description

The current release workflow is failing bc *I think* there's a (or multiple) commits that don't have an email (e.g., commit [46c4cb3](https://github.com/seedcase-project/decisions/commit/46c4cb30f0f2435aafd2261f6860988f21e6f630)*) - which results in a `null` when git cliff tries to run the line `  {% if contributor.username is containing("[bot]") %}` in the new contributors section (maybe bc when there's no email, GitHub can't link it to an account, resulting in a `null` username). 

Adding this line fixes the workflow when I tested it locally at least.

Needs a thorough review.

*When running `git show 46c4cb3`, we get: 

```
commit 46c4cb30f0f2435aafd2261f6860988f21e6f630
Author: lwjohnst86 <null>
Date:   Wed Jul 3 16:43:52 2024 +0000

    🔄 synced local '_extensions/seedcase-project/seedcase-theme/' with remote '_extensions/seedcase-theme/'

diff --git a/_extensions/seedcase-project/seedcase-theme/_extension.yml b/_extensions/seedcase-project/seedcase-theme/_extension.yml
index 27b176b..decfb32 100644
--- a/_extensions/seedcase-project/seedcase-theme/_extension.yml
+++ b/_extensions/seedcase-project/seedcase-theme/_extension.yml
@@ -30,6 +30,17 @@ contributes:
         background: light
         logo: logos/navbar-logo-seedcase-project.svg
         logo-alt: "Seedcase Project logo: Main page"
+      page-footer:
+        border: true
+        center:
+          - text: "License: CC-BY 4.0"
+            href: https://seedcase-project.org/license
+          - text: "Code of Conduct"
+            href: "https://github.com/seedcase-project/.github/blob/main/CODE_OF_CONDUCT.md"
+          - text: "Contributing"
+            href: "https://community.seedcase-project.org/guides/"
+          - text: "Funded by the Novo Nordisk Foundation"
+            href: https://seedcase-project.org/#acknowledgements
     
     csl: vancouver.csl
 ```
